### PR TITLE
Linear cell mode

### DIFF
--- a/nbclearafter/static/main.js
+++ b/nbclearafter/static/main.js
@@ -2,23 +2,50 @@ define([
     'base/js/events'
 ], function (events) {
 
+    var initialize = function () {
+        // add our extension's css to the page
+        $('<link/>')
+            .attr({
+                rel: 'stylesheet',
+                type: 'text/css',
+                href: requirejs.toUrl('./nbclearafter.css')
+            })
+            .appendTo('head');
+    };
+
     // Called every time a cell is executed
     function execute_codecell_callback(e, data) {
         var cell = data.cell;
         var all_cells = cell.notebook.get_cells();
-        var start_clearing = false;
+        var ix_start = all_cells.indexOf(cell);
 
         // Loop through all cells until we find the cell that was just executed
         // Clear output of all cells that come after it.
         for (var i = 0; i < all_cells.length; i++) {
             var cur_cell = all_cells[i];
+            // Skip cells we don't care about
             if (cur_cell.cell_type !== "code") {
-                continue
+                continue;
             }
-            if (start_clearing) {
-                cur_cell.clear_output();
-            } else if (cur_cell.cell_id === cell.cell_id) {
-                start_clearing = true;
+            // Earlier cells should be run in order if they're stale
+            if ((i < ix_start) && cur_cell.element[0].classList.contains('stale')) {
+              cur_cell.execute();
+            }
+            // The current cell should now be editable and active
+            cur_cell.metadata.editable = true;
+            cur_cell.element[0].classList.remove('inactive');
+            cur_cell.element[0].classList.remove('stale');
+            // The next cell is stale but inactive
+            if (i === (ix_start + 1)) {
+              cur_cell.clear_output();
+              cur_cell.element[0].classList.add('stale');
+            }
+            // The remaining cells are both stale and inactive
+            if (i > (ix_start + 1)) {
+              // Subsequent cells are now inactive and stale
+              cur_cell.metadata.editable = false;
+              cur_cell.element[0].classList.add('stale');
+              cur_cell.element[0].classList.add('inactive');
             }
         }
     }

--- a/nbclearafter/static/main.js
+++ b/nbclearafter/static/main.js
@@ -8,7 +8,7 @@ define([
             .attr({
                 rel: 'stylesheet',
                 type: 'text/css',
-                href: requirejs.toUrl('./nbclearafter.css')
+                href: requirejs.toUrl('./static/nbclearafter.css')
             })
             .appendTo('head');
     };
@@ -35,14 +35,17 @@ define([
             cur_cell.metadata.editable = true;
             cur_cell.element[0].classList.remove('inactive');
             cur_cell.element[0].classList.remove('stale');
+
             // The next cell is stale but inactive
             if (i === (ix_start + 1)) {
               cur_cell.clear_output();
+              cur_cell.metadata.editable = false;
               cur_cell.element[0].classList.add('stale');
             }
             // The remaining cells are both stale and inactive
             if (i > (ix_start + 1)) {
               // Subsequent cells are now inactive and stale
+              cur_cell.clear_output();
               cur_cell.metadata.editable = false;
               cur_cell.element[0].classList.add('stale');
               cur_cell.element[0].classList.add('inactive');

--- a/nbclearafter/static/main.js
+++ b/nbclearafter/static/main.js
@@ -1,22 +1,16 @@
 define([
-    'base/js/events'
-], function (events) {
-
-    var initialize = function () {
-        // add our extension's css to the page
-        $('<link/>')
-            .attr({
-                rel: 'stylesheet',
-                type: 'text/css',
-                href: requirejs.toUrl('./static/nbclearafter.css')
-            })
-            .appendTo('head');
-    };
+    'base/js/events',
+    'base/js/namespace',
+    "notebook/js/codecell",
+], function(events, Jupyter, codecell) {
+    var mod_name = 'NBLinear';
+    var log_prefix = '[' + mod_name + ']';
+    var CodeCell = codecell.CodeCell;
 
     // Called every time a cell is executed
-    function execute_codecell_callback(e, data) {
-        var cell = data.cell;
-        var all_cells = cell.notebook.get_cells();
+    function execute_codecell_callback() {
+        var cell = this;
+        var all_cells = this.notebook.get_cells();
         var ix_start = all_cells.indexOf(cell);
 
         // Loop through all cells until we find the cell that was just executed
@@ -50,16 +44,75 @@ define([
               cur_cell.element[0].classList.add('stale');
               cur_cell.element[0].classList.add('inactive');
             }
+
+            if (cur_cell.get_text().length === 0) {
+               cur_cell.editable = true;
+            }
         }
     }
 
-    var load_jupyter_extension = function () {
-        // FIXME: This should instead hook to cell execution *finish*, not start
-        events.on('execute.CodeCell', execute_codecell_callback);
-    };
+    function patch_CodeCell_execute () {
+        console.log(log_prefix, 'Patching CodeCell.prototype.execute for linear flow.');
+        var orig_execute = CodeCell.prototype.execute;
+        CodeCell.prototype.execute = function () {
+            if (Jupyter.linear_mode) {
+                execute_codecell_callback.apply(this, arguments);
+            }
+            var ret = orig_execute.apply(this, arguments);
+            return ret
+        };
+    }
 
-    return {
-        load_ipython_extension: load_jupyter_extension,
-        load_jupyter_extension: load_jupyter_extension
-    };
+    function place_button() {
+      if (!Jupyter.toolbar) {
+          $([Jupyter.events]).on("app_initialized.NotebookApp", place_button);
+          return;
+      }
+      Jupyter.toolbar.add_buttons_group([{
+          label: 'Linear Off',
+          icon: 'fa-arrow-right',
+          callback: toggle_linear
+      }])
+      }
+
+      function toggle_linear() {
+          if (Jupyter.linear_mode) {
+              linear_status = 'off';
+              all_cells = Jupyter.notebook.get_cells();
+              for (var i = 0; i < all_cells.length; i++) {
+                  var cur_cell = all_cells[i];
+                  cur_cell.metadata.editable = true;
+                  cur_cell.element[0].classList.remove('stale');
+                  cur_cell.element[0].classList.remove('inactive');
+                  $("button[title|='Linear Off'] span").text('Linear Off')
+              }
+          } else {
+              linear_status = 'on';
+              $("button[title|='Linear Off'] span").text('Linear On')
+          }
+          Jupyter.linear_mode = !Jupyter.linear_mode;
+          console.info(log_prefix, "Linear mode is " + linear_status)
+      }
+
+      function init_linear_mode() {
+          if (Jupyter.notebook.metadata.linear_mode === true) {
+              Jupyter.linear_mode = true;
+              console.info('blah')
+              $("button[title|='Linear Off'] span").text('Linear On')
+          } else {
+              Jupyter.linear_mode = false;
+          }
+      }
+
+      var load_jupyter_extension = function () {
+          document.styleSheets[0].insertRule("div.inactive span {color: #929292 !important }")
+          patch_CodeCell_execute();
+          place_button();
+          init_linear_mode();
+      };
+
+      return {
+          load_ipython_extension: load_jupyter_extension,
+          load_jupyter_extension: load_jupyter_extension
+      };
 });

--- a/nbclearafter/static/nbclearafter.css
+++ b/nbclearafter/static/nbclearafter.css
@@ -1,0 +1,4 @@
+// Inactive cell styling
+div.inactive span {
+  color: #929292 !important
+};

--- a/nbclearafter/static/nbclearafter.css
+++ b/nbclearafter/static/nbclearafter.css
@@ -1,4 +1,0 @@
-// Inactive cell styling
-div.inactive span {
-  color: #929292 !important;
-};

--- a/nbclearafter/static/nbclearafter.css
+++ b/nbclearafter/static/nbclearafter.css
@@ -1,4 +1,4 @@
 // Inactive cell styling
 div.inactive span {
-  color: #929292 !important
+  color: #929292 !important;
 };


### PR DESCRIPTION
A few changes to add to the clearafter...does the following things:

When a cell is run:

* The N+1th cell gets a "stale" class added to it
* The > N+1th cell gets a "stale" class added and becomes uneditable
When a cell that is stale is run:

* All cells above this one which are also stale are run (in order) first

I also refactored the logic a little bit...

Stuff that is broken or needs doing:

* I can't figure out how to get the CSS to load
* The "all previous stale cells run first" bit is executed _after_ the current cell is run, but it should be before
* There should be a button somewhere to switch this on or off

An example of what this looks like:

![2018-05-18_21-46-10](https://user-images.githubusercontent.com/1839645/40265167-0ae130d4-5ae8-11e8-8701-1719386fb66f.gif)

(NOTE: this is just my general thinking+suggestions here, lemme know what you think)
